### PR TITLE
Add "Unleash the Beast" curse

### DIFF
--- a/RoguemonTracker.lua
+++ b/RoguemonTracker.lua
@@ -249,6 +249,8 @@ local function RoguemonTracker()
 								longDescription = "Your moves' typings are randomized for each battle. This cannot give you STAB on your attacks."},
 		["Distorted Soul"] = {description = "Your moves' powers are randomized.", segment = true, gym = false, romCurse = ROM_CURSES["DISTORTED_SOUL"],
 								longDescription = "Your moves' powers are randomized for each battle, between 30 and 90."},
+		["Unleash the Beast"] = {description = "No FC = Shedinja becomes EternatusE.", segment = true, gym = false,
+	                             longDescription = "If this segment isn't full cleared, all future Shedinja encounters become Eternamax Eternatus instead"},
 	}
 
 	local FIRERED_11_SHA1SUM = "dd5945db9b930750cb39d00c84da8571feebf417"
@@ -1363,6 +1365,9 @@ local function RoguemonTracker()
 
 			-- offset from gBattleStruct
 			distortedSeed        = 0x11,
+
+			-- used to track persistent state of "Unleash the Beast" curse
+			flagCurseUnleash          = 0x4AF,
 		}
 
 		local roguemonSettingPointers = {
@@ -1957,6 +1962,9 @@ local function RoguemonTracker()
 			end
 			if curse == "Poltergeist" then
 				haunted = {}
+			end
+			if curse == "Unleash the Beast" then
+			    self.applyUnleashCurse()
 			end
 		end
 
@@ -7159,6 +7167,18 @@ local function RoguemonTracker()
 		restoreFunctions(LogOverlay, "LogOverlay")
 		restoreFunctions(MoveData, "MoveData")
 		restoreFunctions(io, "io")
+	end
+
+	-- enables the flag turning Shedinja into Eternamax Eternatus.
+	function self.applyUnleashCurse()
+		local flagIdx = GameSettings.roguemon.flagCurseUnleash
+		local flagBit = flagIdx % 8
+		local flagOffset = math.floor((flagIdx - flagBit) / 8)
+
+		local flagAddr = Utils.getSaveBlock1Addr() + GameSettings.gameFlagsOffset + flagOffset
+
+		local newFlags = Memory.readbyte(flagAddr) | (1 << flagBit)
+		Memory.writebyte(flagAddr, newFlags)
 	end
 
 	return self


### PR DESCRIPTION
Adds a new curse which turns future Shedinja encounters into Eternamax Eternatus if the current segment is not full-cleared.

On the ROM side, this is accomplished by checking for the presence of a flag (`0x4AF`) in the trainer battle init function,then passing EternatusE's species ID to `CreateMon()` instead of Shedinja's.

Modifications to the Lua side in support of this curse include the addition of the curse to the `curseInfo` table and an `applyUnleashCurse()` function to set the flag, called by `nextSegment()` if applicable.

__Other considerations for the tracker:__
* The "Special Insight" and "Secret Dex" redeems check in-battle data, so these *should* see EternatusE's stats and not Shedinja's.
* The log will show the Shedinja's data regardless of which pokemon was actually encountered. If the player wishes to see EternatusE's info, they can look it up directly.
   * One potential corner case here is that if the trainer encounter featured a hard-coded moveset, those moves would be applied to EternatusE at time of battle but would not be reflected in the post-game log.

__Future concerns:__
* Currently, the tracker has minimal interaction with the game's standard flags: aside from this curse's function, the `nullifyTrainers()` and `getItemsInCurrentSegment()` functions seem to be the only places where these flags are read in this manner, and no existing functionality writes them. If either of these interactions is needed elsewhere in the future, it should be refactored into `getFlag()` and `setFlag()` and existing functions updated accordingly.
* Similarly, there exist few cases where the effects of a curse exist beyond its segment. If more of these are added in the future, this flag should be moved to a dedicated block of "persistent curses" similar to `ROM_REDEEMS`.

__Debugging:__
* The flag (`0x4af`/`1199`) can be viewed or toggled using the in-game debug menu.
* The flag can be manually set from the Lua console by calling `RoguemonObj().applyUnleashCurse()`.
* The flag's state can be checked from the Lua console using the following command (`0x80` if enabled, `0x00` otherwise):

```
string.format("0x%02X", Memory.readbyte(Utils.getSaveBlock1Addr() + GameSettings.gameFlagsOffset + (0x4A8/8)))
```